### PR TITLE
Added preservation of most repeated note

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,19 +25,20 @@ def merge_duplicates(browser: Browser) -> None:
 
     for card in cards:
         note = card.note()
-        if note.id not in [n.id for n in notes]:
-            notes.append(note)
+        if note.id not in [n.id for n,_ in notes]:
+            notes.append((note, card.reps))
 
     dups: dict[list[Note]] = {}
-    for note in notes:
+    for note, reps in notes:
         fields = note.items()
-        dups.setdefault(fields[0], []).append(note)
+        dups.setdefault(fields[0], []).append((note, reps))
 
     browser.model.beginReset()
     browser.mw.checkpoint("merge fields of duplicates")
 
     del_note_ids = []
     for dupl in dups.values():
+        dupl = [note for note, reps in sorted(dupl, key=lambda x: -x[1])] 
         for i in range(1, len(dupl)):
             merge_notes(dupl[0], dupl[i])
             del_note_ids.append(dupl[i].id)


### PR DESCRIPTION
Currently, the addon preserves the first note it encounters in a series of duplicates. This means that scheduling data of other notes/cards will be lost, even if they have been repeated many more times than the first encountered note. 

With this change, the amount of times the card corresponding to a note has been repeated is kept alongside that note. When it is time to merge a list of duplicate notes, they are first sorted by the negative of their rep number, so that the note with the highest number of reps is the one that survives.