### PR TITLE
Allow to configure how entires should be merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the addon from [AnkiWeb](https://ankiweb.net/shared/info/55394168) or ma
 
 Select any number of notes/cards in the browser, right-click, and press "Merge duplicate notes".
 
-Of all the selected notes, any duplicates (i.e. the first field being equal) will be merged together, always taking the longer value of each field. The tags of all notes are combined, i.e. the merged note will have all the tags any of the original notes had.
+Of all the selected notes, any duplicates (i.e. the first field being equal) will be merged together. The merging strategy can be configured, see bellow. The tags of all notes are combined, i.e. the merged note will have all the tags any of the original notes had.
 
 Say for example you select these notes:
 
@@ -24,7 +24,7 @@ and press "Merge duplicate notes".
 
 The first two notes, their first field being equal, will be detected as duplicates of each other. So these two notes will be combined into one note, whereas the "apple" note will remain untouched.
 
-For the "Description" field, the first note has the longer value, so the merged note will have it's "Description" value. For the "Audio" field however, the second note has the longer value (the field being empty for the first note), so the merged note will have it's "Audio" value.
+When two notes that get merged have different values in one field, the default strategy is to pick the longer one.In the example for the "Description" field, the first note has the longer value, so the merged note will have it's "Description" value. For the "Audio" field however, the second note has the longer value (the field being empty for the first note), so the merged note will have it's "Audio" value.
 
 The tags will be combined of the two notes.
 
@@ -37,8 +37,11 @@ apple | a round, red or green fruit | | fruit
 
 ## Config
 
-Currently the addon has no configuration.
+Currently the configuration has only one option `merge_mode`, it can be set to the following values:
+* `longer` (default) – The longer content of the notes will be kept for the merged note, see above.
+* `concat` – The contents of both notes will be concatenated for the new note.
+* `skip` – Notes will only get merged if there are no conflicting fields. Merges will only happen if for all fields both notes have the same value or one note has no value.
 
-Though if you are comfortable with Python and want to change something, you should be able to just change the addon yourself, it's very small. Click "View files" in the addon menu in Anki to get to the folder, and open `__init__.py`.
+If you are comfortable with Python and want to change something, you should be able to just change the addon yourself, it's very small. Click "View files" in the addon menu in Anki to get to the folder, and open `__init__.py`.
 
 _Note:_ If you have installed the addon from AnkiWeb, if I ever push an update of the addon there, any local changes will be overwritten when it gets updated. If you install the addon manually, this will not happen. 

--- a/__init__.py
+++ b/__init__.py
@@ -1,15 +1,23 @@
 from anki.notes import Note
-from aqt import mw
-from aqt.utils import tooltip, qconnect
-from aqt.qt import *
+from aqt import gui_hooks, mw
 from aqt.browser import Browser
-from aqt import gui_hooks
+from aqt.qt import *
+from aqt.utils import qconnect, showCritical, tooltip
+
+config = mw.addonManager.getConfig(__name__)
 
 
-def merge_notes(note0: Note, note: Note) -> None:
+def merge_notes(note0: Note, note: Note, mode: str) -> None:
     for f in note.keys():
-        if f in note0 and len(note[f]) > len(note0[f]):
-            note0[f] = note[f]
+        if f in note0 and note0[f] != note[f]:
+            if mode == "concat":
+                note0[f] += note[f]
+            elif mode == "longer" and len(note[f]) > len(note0[f]):
+                note0[f] = note[f]
+            elif mode == "skip":
+                raise ValueError("Conflicting entries")
+            else:
+                raise NotImplementedError("Unknown mode %s" % mode)
 
     for t in note.tags:
         if not note0.hasTag(t):
@@ -19,13 +27,14 @@ def merge_notes(note0: Note, note: Note) -> None:
 
 
 def merge_duplicates(browser: Browser) -> None:
+    mode = config.get("merge_mode", "longer")
     cardids = browser.selectedCards()
     cards = [mw.col.getCard(id) for id in cardids]
     notes = []
 
     for card in cards:
         note = card.note()
-        if note.id not in [n.id for n,_ in notes]:
+        if note.id not in [n.id for n, _ in notes]:
             notes.append((note, card.reps))
 
     dups: dict[list[Note]] = {}
@@ -38,10 +47,16 @@ def merge_duplicates(browser: Browser) -> None:
 
     del_note_ids = []
     for dupl in dups.values():
-        dupl = [note for note, reps in sorted(dupl, key=lambda x: -x[1])] 
+        dupl = [note for note, reps in sorted(dupl, key=lambda x: -x[1])]
         for i in range(1, len(dupl)):
-            merge_notes(dupl[0], dupl[i])
-            del_note_ids.append(dupl[i].id)
+            try:
+                merge_notes(dupl[0], dupl[i], mode)
+                del_note_ids.append(dupl[i].id)
+            except ValueError:
+                pass
+            except NotImplementedError:
+                showCritical("Invalid configuration", parent=browser)
+                return
 
     browser.mw.col.remNotes(del_note_ids)
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+	"merge_mode": "longer"
+}


### PR DESCRIPTION
This allows to set a configuration option in order to change the merging strategy. The previous behavior is still the default, called `longer`. Alternatives added are `concat` and `skip`. Further modes could be added: older, newer, concat with newline, …