### PR TITLE
Fix "Invalid configuration" when mode is "longer" and note0 is longer than duplicate note

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,8 +12,9 @@ def merge_notes(note0: Note, note: Note, mode: str) -> None:
         if f in note0 and note0[f] != note[f]:
             if mode == "concat":
                 note0[f] += note[f]
-            elif mode == "longer" and len(note[f]) > len(note0[f]):
-                note0[f] = note[f]
+            elif mode == "longer"
+                if len(note[f]) > len(note0[f]):
+                    note0[f] = note[f]
             elif mode == "skip":
                 raise ValueError("Conflicting entries")
             else:

--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,7 @@ def merge_notes(note0: Note, note: Note, mode: str) -> None:
         if f in note0 and note0[f] != note[f]:
             if mode == "concat":
                 note0[f] += note[f]
-            elif mode == "longer"
+            elif mode == "longer":
                 if len(note[f]) > len(note0[f]):
                     note0[f] = note[f]
             elif mode == "skip":


### PR DESCRIPTION
Fix "Invalid configuration" when mode is "longer" and note0 is longer than duplicate note