### PR TITLE
Add a keyboard shortcut for merging duplicate notes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -73,6 +73,7 @@ def merge_duplicates(browser: Browser) -> None:
 def setup_context_menu(browser: Browser):
     menu = browser.form.menu_Cards
     merge_action = menu.addAction("Merge duplicate notes")
+    merge_action.setShortcut(QKeySequence("Ctrl+M"))
     qconnect(merge_action.triggered, browser.onMergeDuplicates)
 
 


### PR DESCRIPTION
Adds a keyboard shortcut to make merging duplicates a little quicker. Thanks for this addon!

Tested locally, OS X works great.

<img width="291" alt="Screenshot 2023-12-29 at 12 46 56 PM" src="https://github.com/Garbaz/anki-merge-duplicates/assets/492903/677d137a-e837-454b-8cbc-1ebc6020722e">
