### PR TITLE
Add 'first' merging strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ apple | a round, red or green fruit | | fruit
 Currently the configuration has only one option `merge_mode`, it can be set to the following values:
 * `longer` (default) – The longer content of the notes will be kept for the merged note, see above.
 * `concat` – The contents of both notes will be concatenated for the new note.
+* `first` – Keep the field contents of the first card only.
 * `skip` – Notes will only get merged if there are no conflicting fields. Merges will only happen if for all fields both notes have the same value or one note has no value.
 
 If you are comfortable with Python and want to change something, you should be able to just change the addon yourself, it's very small. Click "View files" in the addon menu in Anki to get to the folder, and open `__init__.py`.
 
-_Note:_ If you have installed the addon from AnkiWeb, if I ever push an update of the addon there, any local changes will be overwritten when it gets updated. If you install the addon manually, this will not happen. 
+_Note:_ If you have installed the addon from AnkiWeb, if I ever push an update of the addon there, any local changes will be overwritten when it gets updated. If you install the addon manually, this will not happen.

--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,8 @@ def merge_notes(note0: Note, note: Note, mode: str) -> None:
             elif mode == "longer":
                 if len(note[f]) > len(note0[f]):
                     note0[f] = note[f]
+            elif mode == "first":
+                pass # No-op, note0 already has its own info which it's keeping.
             elif mode == "skip":
                 raise ValueError("Conflicting entries")
             else:


### PR DESCRIPTION
I have a use case where I needed to "merge" (a.k.a. mass delete) duplicate notes. I have fields like "Sentence English" and "Sentence Chinese" which can have different lengths, but need to be merged in a consistent way (so "longest" doesn't work). Adding this new option to just keep the fields on the first card.